### PR TITLE
dev-libs/rocr-runtime: Build without LTO

### DIFF
--- a/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
+++ b/sys-config/ltoize/files/package.cflags/ltoworkarounds.conf
@@ -126,6 +126,7 @@ sys-fs/cryfs *FLAGS-=-flto* # Test failure
 app-crypt/gcr *FLAGS-=-flto* # Test failure
 dev-scheme/gambit *FLAGS-=-flto* # Runtime errors when gsc when built with LTO on > GCC 8
 media-libs/mesa "has video_cards_i965 ${IUSE//+} && use video_cards_i965 && FlagSubAllFlags -flto*"
+dev-libs/rocr-runtime *FLAGS-=-flto* # Causes crashes in multiple OpenCL tools
 # END: LTO not recommended
 
 #Packages which Graphite optimizations don't play nice with


### PR DESCRIPTION
Title: <category>/<package>: <description>

Ensure that any added workarounds have a comment explaining the compilation error which requires it.
Any removed workarounds should be moved to the fixed section.
If an issue exists, please link it.
See .github/CONTRIBUTING.md for more information.
